### PR TITLE
Updated elife/patterns to 654fa14: Updated pattern-library to b5e3eb9: Catch errors thrown by text-clipper library

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -68,12 +68,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "8bb730ffb0d7fc0c0e27f29ba91b719010a482c1"
+                "reference": "654fa1452a9175d6066f66c1802e57c71c3f72fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/8bb730ffb0d7fc0c0e27f29ba91b719010a482c1",
-                "reference": "8bb730ffb0d7fc0c0e27f29ba91b719010a482c1",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/654fa1452a9175d6066f66c1802e57c71c3f72fa",
+                "reference": "654fa1452a9175d6066f66c1802e57c71c3f72fa",
                 "shasum": ""
             },
             "require": {
@@ -106,7 +106,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-11-09T11:26:10+00:00"
+            "time": "2017-11-10T09:56:51+00:00"
         },
         {
             "name": "mindplay/composer-locator",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies-error-pages-update-patterns-php/261/display/redirect which resulted in this pull request.