### PR TITLE
Only update composer.lock if needed

### DIFF
--- a/Jenkinsfile.update-patterns-php
+++ b/Jenkinsfile.update-patterns-php
@@ -4,7 +4,10 @@ elifeUpdatePipeline(
         elifeWaitPackagist "elife/patterns", params.revision
         sh "composer update elife/patterns --no-interaction"
         sh "bin/update"
-        sh "git add --all composer.lock public/"
+        sh "git add --all public/"
+        if (elifeGitDifferences()) {
+            sh "git add composer.lock"
+        }
     },
     {
         def subrepositorySummary = elifeGitSubrepositorySummary 'vendor/elife/patterns'


### PR DESCRIPTION
Smoke-tested with https://alfred.elifesciences.org/job/dependencies-error-pages-update-patterns-php/263/console which is a replay performed with this Jenkinsfile. There was nothing to update there so only a partial test.