### PR TITLE
Updated elife/patterns to 8c9af77: Updated pattern-library to 417e6f1: ELPP-3598 Remove non-ASCII characters from error pages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "90ec352ee06a0cb4cc33b3c7313c3826",
@@ -68,12 +68,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "674f39bd248dd9775e28d4fb8b6a45bac0dbf6f5"
+                "reference": "8c9af770a98c3da0ac4c3369e4a961d961f3e91b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/674f39bd248dd9775e28d4fb8b6a45bac0dbf6f5",
-                "reference": "674f39bd248dd9775e28d4fb8b6a45bac0dbf6f5",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/8c9af770a98c3da0ac4c3369e4a961d961f3e91b",
+                "reference": "8c9af770a98c3da0ac4c3369e4a961d961f3e91b",
                 "shasum": ""
             },
             "require": {
@@ -109,7 +109,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2018-04-18T12:31:48+00:00"
+            "time": "2018-05-17T15:37:17+00:00"
         },
         {
             "name": "mindplay/composer-locator",

--- a/public/4xx.html
+++ b/public/4xx.html
@@ -50,7 +50,7 @@
 
     <h1 class="error__title">Say what?</h1>
 
-    <p>Your browser sent us something unexpected.<br>We’ve logged the problem and will look into it.</p>
+    <p>Your browser sent us something unexpected.<br>We&#x2019;ve logged the problem and will look into it.</p>
 
 
   </div>

--- a/public/503.html
+++ b/public/503.html
@@ -50,7 +50,7 @@
 
     <h1 class="error__title">Back soon</h1>
 
-    <p>We’re carrying out planned maintenance on this page.</p>
+    <p>We&#x2019;re carrying out planned maintenance on this page.</p>
 
 
   </div>

--- a/public/5xx.html
+++ b/public/5xx.html
@@ -50,7 +50,7 @@
 
     <h1 class="error__title">Kabooooooom!</h1>
 
-    <p>Something has gone seriously wrong.<br>We’ve logged the problem and will look into it.</p>
+    <p>Something has gone seriously wrong.<br>We&#x2019;ve logged the problem and will look into it.</p>
 
 
   </div>


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-error-pages-update-patterns-php/347/display/redirect which resulted in this pull request.